### PR TITLE
test: remove unused conditions in base64 util

### DIFF
--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -17,9 +17,7 @@ function b64ToUint6(nChr: number): number {
     ? nChr + 4
     : nChr === 43
     ? 62
-    : nChr === 47
-    ? 63
-    : 0;
+    : 63;
 }
 
 export function base64Decode(str: string): Uint8Array {
@@ -60,9 +58,7 @@ function uint6ToB64(nUint6: number): number {
     ? nUint6 - 4
     : nUint6 === 62
     ? 43
-    : nUint6 === 63
-    ? 47
-    : 65;
+    : 47;
 }
 
 export function base64Encode(bytes: Uint8Array): string {


### PR DESCRIPTION
These are unreachable because a Uint6 can never be greater than 63